### PR TITLE
Fix docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,12 @@ IPython2CWL is a tool for converting [IPython](https://ipython.org/) Jupyter Not
 ```python
 from ipython2cwl.iotypes import CWLFilePathInput, CWLFilePathOutput
 import csv
-input_filename: CWLFilePathInput = 'data.csv'
+input_filename: 'CWLFilePathInput' = 'data.csv'
 with open(input_filename) as f:
     csv_reader = csv.reader(f)
     data = [line for line in csv_reader]
 number_of_lines = len(data)
-result_file: CWLFilePathOutput = 'number_of_lines.txt'
+result_file: 'CWLFilePathOutput' = 'number_of_lines.txt'
 with open(result_file, 'w') as f:
     f.write(str(number_of_lines))
 ```
@@ -37,7 +37,7 @@ pip install ipython2cwl
 ```
 
 ### Example
- 
+
 ```
 jupyter repo2cwl https://github.com/giannisdoukas/cwl-annotated-jupyter-notebook.git -o .
 ```

--- a/README.md
+++ b/README.md
@@ -14,14 +14,14 @@ IPython2CWL is a tool for converting [IPython](https://ipython.org/) Jupyter Not
 ```python
 from ipython2cwl.iotypes import CWLFilePathInput, CWLFilePathOutput
 import csv
-input_filename: 'CWLFilePathInput' = 'data.csv'
+input_filename: CWLFilePathInput = 'data.csv'
 with open(input_filename) as f:
-  csv_reader = csv.reader(f)
-  data = [line for line in csv_reader]
+    csv_reader = csv.reader(f)
+    data = [line for line in csv_reader]
 number_of_lines = len(data)
-result_file: 'CWLFilePathOutput' = 'number_of_lines.txt'
+result_file: CWLFilePathOutput = 'number_of_lines.txt'
 with open(result_file, 'w') as f:
-  f.write(str(number_of_lines))
+    f.write(str(number_of_lines))
 ```
 
 IPython2CWL is based on [repo2docker](https://github.com/jupyter/repo2docker), the same tool

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -19,12 +19,12 @@ IPython2CWL is a tool for converting `IPython <https://ipython.org/>`_ Jupyter N
 
     from ipython2cwl.iotypes import CWLFilePathInput, CWLFilePathOutput
     import csv
-    input_filename: CWLFilePathInput = 'data.csv'
+    input_filename: 'CWLFilePathInput' = 'data.csv'
     with open(input_filename) as f:
         csv_reader = csv.reader(f)
         data = [line for line in csv_reader]
     number_of_lines = len(data)
-    result_file: CWLFilePathOutput = 'number_of_lines.txt'
+    result_file: 'CWLFilePathOutput' = 'number_of_lines.txt'
     with open(result_file, 'w') as f:
         f.write(str(number_of_lines))
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -19,14 +19,14 @@ IPython2CWL is a tool for converting `IPython <https://ipython.org/>`_ Jupyter N
 
     from ipython2cwl.iotypes import CWLFilePathInput, CWLFilePathOutput
     import csv
-    input_filename: 'CWLFilePathInput' = 'data.csv'
+    input_filename: CWLFilePathInput = 'data.csv'
     with open(input_filename) as f:
-      csv_reader = csv.reader(f)
-      data = [line for line in csv_reader]
+        csv_reader = csv.reader(f)
+        data = [line for line in csv_reader]
     number_of_lines = len(data)
-    result_file: 'CWLFilePathOutput' = 'number_of_lines.txt'
+    result_file: CWLFilePathOutput = 'number_of_lines.txt'
     with open(result_file, 'w') as f:
-      f.write(str(number_of_lines))
+        f.write(str(number_of_lines))
 
 
 ------------------------------------------------------------------------------------------
@@ -79,4 +79,3 @@ WHAT IF I WANT TO VALIDATE THAT THE GENERATED SCRIPTS ARE CORRECT?
 
 All the generated scripts are stored in the docker image under the directory :code:`/app/cwl/bin`. You can see the list
 of the files by running :code:`docker run [IMAGE_ID] find /app/cwl/bin/ -type f`.
-

--- a/ipython2cwl/iotypes.py
+++ b/ipython2cwl/iotypes.py
@@ -45,7 +45,7 @@ class CWLFilePathInput(str, _CWLInput):
     will be created and the assignment of value will be generalised.
 
     >>> dataset1: CWLFilePathInput = './data/data.csv'
-    >>> dataset2: CWLFilePathInput = './data/data.csv'
+    >>> dataset2: 'CWLFilePathInput' = './data/data.csv'
 
     """
     pass
@@ -57,7 +57,7 @@ class CWLBooleanInput(_CWLInput):
     will be created and the assignment of value will be generalised.
 
     >>> dataset1: CWLBooleanInput = True
-    >>> dataset2: CWLBooleanInput = False
+    >>> dataset2: 'CWLBooleanInput' = False
 
     """
     pass
@@ -69,7 +69,7 @@ class CWLStringInput(str, _CWLInput):
     will be created and the assignment of value will be generalised.
 
     >>> dataset1: CWLStringInput = 'this is a message input'
-    >>> dataset2: CWLStringInput = 'yet another message input'
+    >>> dataset2: 'CWLStringInput' = 'yet another message input'
 
     """
     pass
@@ -81,7 +81,7 @@ class CWLIntInput(_CWLInput):
     will be created and the assignment of value will be generalised.
 
     >>> dataset1: CWLIntInput = 1
-    >>> dataset2: CWLIntInput = 2
+    >>> dataset2: 'CWLIntInput' = 2
 
     """
     pass

--- a/ipython2cwl/iotypes.py
+++ b/ipython2cwl/iotypes.py
@@ -45,7 +45,7 @@ class CWLFilePathInput(str, _CWLInput):
     will be created and the assignment of value will be generalised.
 
     >>> dataset1: CWLFilePathInput = './data/data.csv'
-    >>> dataset2: 'CWLFilePathInput' = './data/data.csv'
+    >>> dataset2: CWLFilePathInput = './data/data.csv'
 
     """
     pass
@@ -57,7 +57,7 @@ class CWLBooleanInput(_CWLInput):
     will be created and the assignment of value will be generalised.
 
     >>> dataset1: CWLBooleanInput = True
-    >>> dataset2: 'CWLBooleanInput' = False
+    >>> dataset2: CWLBooleanInput = False
 
     """
     pass
@@ -65,13 +65,13 @@ class CWLBooleanInput(_CWLInput):
 
 class CWLStringInput(str, _CWLInput):
     """Use that hint to annotate that a variable is a string input. You can use the typing annotation
-        as a string by importing it. At the generated script a command line argument with the name of the variable
-        will be created and the assignment of value will be generalised.
+    as a string by importing it. At the generated script a command line argument with the name of the variable
+    will be created and the assignment of value will be generalised.
 
-        >>> dataset1: CWLBooleanInput = 'this is a message input'
-        >>> dataset2: 'CWLBooleanInput' = 'yet another message input'
+    >>> dataset1: CWLStringInput = 'this is a message input'
+    >>> dataset2: CWLStringInput = 'yet another message input'
 
-        """
+    """
     pass
 
 
@@ -80,8 +80,8 @@ class CWLIntInput(_CWLInput):
     as a string by importing it. At the generated script a command line argument with the name of the variable
     will be created and the assignment of value will be generalised.
 
-    >>> dataset1: CWLBooleanInput = 1
-    >>> dataset2: 'CWLBooleanInput' = 2
+    >>> dataset1: CWLIntInput = 1
+    >>> dataset2: CWLIntInput = 2
 
     """
     pass
@@ -95,7 +95,7 @@ class CWLFilePathOutput(str, _CWLOutput):
     """Use that hint to annotate that a variable is a string-path to an output file. You can use the typing annotation
     as a string by importing it. The generated file will be mapped as a CWL output.
 
-    >>> filename: CWLBooleanInput = 'data.csv'
+    >>> filename: CWLFilePathOutput = 'data.csv'
 
     """
     pass
@@ -111,7 +111,7 @@ class CWLDumpable(_CWLOutput):
 
         >>> import pandas
         >>> d: CWLDumpable.dump(d.to_csv, "dumpable.csv", sep="\\t", index=False) = pandas.DataFrame(
-        ...     [[1,2,3], [4,5,6], [7,8,9]]
+        ...     [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
         ... )
 
         In that example the converter will add at the end of the script the following line:
@@ -132,13 +132,10 @@ class CWLDumpableFile(CWLDumpable):
 
     >>> data: CWLDumpableFile = "this is text data"
 
-
     the converter will append at the end of the script the following lines:
-
 
     >>> with open('data', 'w') as f:
     ...     f.write(data)
-
 
     and at the CWL, the data, will be mapped as a output.
     """
@@ -165,14 +162,14 @@ class CWLPNGPlot(CWLDumpable):
     be called.
 
     >>> import matplotlib.pyplot as plt
-    >>> data = [1,2,3]
-    >>> new_data: 'CWLPNGPlot' = plt.plot(data)
+    >>> data = [1, 2, 3]
+    >>> new_data: CWLPNGPlot = plt.plot(data)
 
     the converter will tranform these lines to
 
     >>> import matplotlib.pyplot as plt
-    >>> data = [1,2,3]
-    >>> new_data: 'CWLPNGPlot' = plt.plot(data)
+    >>> data = [1, 2, 3]
+    >>> new_data: CWLPNGPlot = plt.plot(data)
     >>> plt.savefig('new_data.png')
 
 
@@ -181,9 +178,9 @@ class CWLPNGPlot(CWLDumpable):
     To do that in your notebook you have to create a new figure before the plot command or use the CWLPNGFigure.
 
     >>> import matplotlib.pyplot as plt
-    >>> data = [1,2,3]
+    >>> data = [1, 2, 3]
     >>> plt.figure()
-    >>> new_data: 'CWLPNGPlot' = plt.plot(data)
+    >>> new_data: CWLPNGPlot = plt.plot(data)
     """
     pass
 
@@ -194,14 +191,13 @@ class CWLPNGFigure(CWLDumpable):
 
     >>> import matplotlib.pyplot as plt
     >>> data = [1,2,3]
-    >>> new_data: 'CWLPNGPlot' = plt.plot(data)
+    >>> new_data: CWLPNGFigure = plt.plot(data)
 
     the converter will tranform these lines to
 
     >>> import matplotlib.pyplot as plt
-    >>> data = [1,2,3]
+    >>> data = [1, 2, 3]
     >>> plt.figure()
-    >>> new_data: 'CWLPNGPlot' = plt.plot(data)
+    >>> new_data: CWLPNGFigure = plt.plot(data)
     >>> plt.savefig('new_data.png')
-
     """


### PR DESCRIPTION
I think it's a very good project.
I'll try to use it in more detail after this.
I'll send you a pull request for what's interesting in the docs first.

The fixes are as follows:

- Fix some indents in the example code.

e.g.

```
with open(input_filename) as f:
  csv_reader = csv.reader(f)
```

- Specify type annotation with a class instead of a string in the class name.
  - I apologize if you use this notation as an expected behavior.

e.g.

```
>>> dataset2: 'CWLFilePathInput' = './data/data.csv'
```

- Fix a mistake in the class specification for type annotation

e.g.

```
>>> dataset1: CWLBooleanInput = 1
>>> dataset2: 'CWLBooleanInput' = 2
```
