### PR TITLE
Add docker environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM python:3.6.11-slim-buster
+
+RUN apt update && \
+    apt install -y --no-install-recommends \
+    git \
+    tini && \
+    apt clean &&\
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY . .
+
+RUN pip install -U pip setuptools wheel && \
+    python3 setup.py install
+
+ENV UID=1000
+RUN useradd -M -u ${UID} -U jupyter
+
+USER jupyter
+
+ENTRYPOINT ["tini", "--"]
+CMD ["jupyter-repo2cwl"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: "3"
+services:
+  app:
+    image: ipython2cwl
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: ipython2cwl
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ${PWD}:/app
+    working_dir: /app
+    restart: always
+    user: "1000:root"
+    command: ["jupyter-repo2cwl"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,5 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
       - ${PWD}:/app
     working_dir: /app
-    restart: always
     user: "1000:root"
     command: ["jupyter-repo2cwl"]


### PR DESCRIPTION
Add a docker environment to run the ipython2cwl itself in the docker container.

```bash
$ docker-compose up jupyter-repo2cwl https://github.com/giannisdoukas/ipython2cwl-demo -o .
```

It is able to run using the above command on the host machine.
Because it is mounting `/var/run/docker.sock` in `docker-compose.yml`, the image is generated in the host docker environment.
Therefore, it is able to execute the following command on the host machine.

```bash
$ docker run -p 127.0.0.1:8888:8888 THE_NAME_OF_THE_GENERATED_IMAGE
```