### PR TITLE
bumped nbconvert version in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ setup(
         'PyYAML>=5.3.1',
         'gitpython>=3.1.3',
         'jupyter-repo2docker>=0.11.0',
-        'nbconvert==5.6.1',
+        'nbconvert>=6.4.4',
         'ipython>=7.15.0'
     ],
     test_suite='tests',


### PR DESCRIPTION
The library is currently nonfunctional due to a compatibility issue in nbconvert. this PR permits future installations to pull the latest, which does function with the latest `7.16.6` version.