### PR TITLE
Add CWLFloatInput to the available annotations

### DIFF
--- a/ipython2cwl/cwltoolextractor.py
+++ b/ipython2cwl/cwltoolextractor.py
@@ -14,8 +14,8 @@ import nbconvert  # type: ignore
 import yaml
 from nbformat.notebooknode import NotebookNode  # type: ignore
 
-from .iotypes import CWLFilePathInput, CWLBooleanInput, CWLIntInput, CWLStringInput, CWLFilePathOutput, \
-    CWLDumpableFile, CWLDumpableBinaryFile, CWLDumpable, CWLPNGPlot, CWLPNGFigure
+from .iotypes import CWLFilePathInput, CWLBooleanInput, CWLIntInput, CWLFloatInput, CWLStringInput, \
+    CWLFilePathOutput, CWLDumpableFile, CWLDumpableBinaryFile, CWLDumpable, CWLPNGPlot, CWLPNGFigure
 from .requirements_manager import RequirementsManager
 
 with open(os.sep.join([os.path.abspath(os.path.dirname(__file__)), 'templates', 'template.dockerfile'])) as f:
@@ -45,6 +45,10 @@ class AnnotatedVariablesExtractor(ast.NodeTransformer):
         (CWLIntInput.__name__,): (
             'int',
             'int',
+        ),
+        (CWLFloatInput.__name__,): (
+            'float',
+            'float',
         ),
         (CWLStringInput.__name__,): (
             'string',

--- a/ipython2cwl/iotypes.py
+++ b/ipython2cwl/iotypes.py
@@ -15,6 +15,8 @@ Each variable can be an input or an output. The basic data types are:
 
   * CWLIntInput
 
+  * CWLFloatInput
+
 * Outputs:
 
   * CWLFilePathOutput
@@ -82,6 +84,17 @@ class CWLIntInput(_CWLInput):
 
     >>> dataset1: CWLIntInput = 1
     >>> dataset2: 'CWLIntInput' = 2
+
+    """
+    pass
+
+class CWLFloatInput(_CWLInput):
+    """Use that hint to annotate that a variable is a float input. You can use the typing annotation
+    as a string by importing it. At the generated script a command line argument with the name of the variable
+    will be created and the assignment of value will be generalised.
+
+    >>> dataset1: CWLFloatInput = 1.0
+    >>> dataset2: 'CWLFloatInput' = 2.0
 
     """
     pass

--- a/tests/test_cwltoolextractor.py
+++ b/tests/test_cwltoolextractor.py
@@ -18,7 +18,8 @@ class TestCWLTool(TestCase):
             "import csv",
             "input_filename: CWLFilePathInput = 'data.csv'",
             "flag: CWLBooleanInput = true",
-            "num: CWLIntInput = 1",
+            "num_int: CWLIntInput = 1",
+            "num_float: CWLFloatInput = 1.0",
             "msg: CWLStringInput = 'hello world'",
             "with open(input_filename) as f:",
             "\tcsv_reader = csv.reader(f)",
@@ -50,10 +51,16 @@ class TestCWLTool(TestCase):
                             'prefix': '--flag'
                         }
                     },
-                    'num': {
+                    'num_int': {
                         'type': 'int',
                         'inputBinding': {
-                            'prefix': '--num'
+                            'prefix': '--num_int'
+                        }
+                    },
+                    'num_float': {
+                        'type': 'float',
+                        'inputBinding': {
+                            'prefix': '--num_float'
                         }
                     },
                     'msg': {


### PR DESCRIPTION
This pull request introduces support for float input variables in the CWL tool extraction workflow. The main change is the addition of the `CWLFloatInput` type, which allows users to annotate float inputs in their scripts and ensures they are properly handled and represented in the generated CWL tool definitions and command-line interfaces.
